### PR TITLE
chore: removing an unused choco script

### DIFF
--- a/tools/choco
+++ b/tools/choco
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker run -v $PWD:/build -w /build chocolatey/choco:v2.2.2-linux choco $@


### PR DESCRIPTION
There is a script that was used to call the choco tool that is no longer being used. This PR removes it.