### PR TITLE
fix: new mac seems to be breaking pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The new macos runners seem to be break colima. See here: https://github.com/abiosoft/colima/issues/1023