### PR TITLE
fix: ignoring files added when installing Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 .vscode
 .vale.ini
 styles
+colima-Darwin-x86_64
+install.log


### PR DESCRIPTION
The action to install Docker causes goreleaser to fail. I've adjusted the gitignore to account for that.