### PR TITLE
fix: the windows manifest paths need to be different

### DIFF
--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -184,7 +184,7 @@ func firefoxManifestInternal(goos string, getenv getenvFn, userHome userHomeFn, 
 		folder = join(home, ".mozilla", "native-messaging-hosts")
 	} else if goos == "windows" {
 		// The manifest can be anywhere in Windows, but it needs a supporting registry entry.
-		folder = join(home, "AppData", "Local", "Armaria")
+		folder = join(home, "AppData", "Local", "Armaria", "Firefox")
 	} else if goos == "darwin" {
 		folder = join(home, "Library", "Application Support", "Mozilla", "NativeMessagingHosts")
 	} else {
@@ -219,7 +219,7 @@ func chromeManifestInternal(goos string, getenv getenvFn, userHome userHomeFn, j
 		folder = join(home, ".config", "google-chrome", "NativeMessagingHosts")
 	} else if goos == "windows" {
 		// The manifest can be anywhere in Windows, but it needs a supporting registry entry.
-		folder = join(home, "AppData", "Local", "Armaria")
+		folder = join(home, "AppData", "Local", "Armaria", "Chrome")
 	} else if goos == "darwin" {
 		folder = join(home, "Library", "Application Support", "Google", "Chrome", "NativeMessagingHosts")
 	} else {
@@ -254,7 +254,7 @@ func chromiumManifestInternal(goos string, getenv getenvFn, userHome userHomeFn,
 		folder = join(home, ".config", "chromium", "NativeMessagingHosts")
 	} else if goos == "windows" {
 		// The manifest can be anywhere in Windows, but it needs a supporting registry entry.
-		folder = join(home, "AppData", "Local", "Armaria")
+		folder = join(home, "AppData", "Local", "Armaria", "Chrome")
 	} else if goos == "darwin" {
 		folder = join(home, "Library", "Application Support", "Chromium", "NativeMessagingHosts")
 	} else {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -289,9 +289,9 @@ func TestFirefoxManifestPath(t *testing.T) {
 	tests := []test{
 		{
 			goos:          "windows",
-			folderPath:    "~/AppData/Local/Armaria",
+			folderPath:    "~/AppData/Local/Armaria/Firefox",
 			folderCreated: true,
-			manifestPath:  "~/AppData/Local/Armaria/armaria.json",
+			manifestPath:  "~/AppData/Local/Armaria/Firefox/armaria.json",
 		},
 		{
 			goos:          "linux",
@@ -363,9 +363,9 @@ func TestChromeManifestPath(t *testing.T) {
 	tests := []test{
 		{
 			goos:          "windows",
-			folderPath:    "~/AppData/Local/Armaria",
+			folderPath:    "~/AppData/Local/Armaria/Chrome",
 			folderCreated: true,
-			manifestPath:  "~/AppData/Local/Armaria/armaria.json",
+			manifestPath:  "~/AppData/Local/Armaria/Chrome/armaria.json",
 		},
 		{
 			goos:          "linux",
@@ -437,9 +437,9 @@ func TestChromiumManifestPath(t *testing.T) {
 	tests := []test{
 		{
 			goos:          "windows",
-			folderPath:    "~/AppData/Local/Armaria",
+			folderPath:    "~/AppData/Local/Armaria/Chrome",
 			folderCreated: true,
-			manifestPath:  "~/AppData/Local/Armaria/armaria.json",
+			manifestPath:  "~/AppData/Local/Armaria/Chrome/armaria.json",
 		},
 		{
 			goos:          "linux",


### PR DESCRIPTION
The windows manifest paths need to different. As it stands the different manifests are overwriting each other which causes breakages.